### PR TITLE
Add safe navigator in `whitelist_charges`

### DIFF
--- a/lib/lago/api/resources/plan.rb
+++ b/lib/lago/api/resources/plan.rb
@@ -36,7 +36,7 @@ module Lago
         def whitelist_charges(charges)
           processed_charges = []
 
-          charges.each do |c|
+          charges&.each do |c|
             result = (c || {}).slice(
               :id,
               :billable_metric_id,


### PR DESCRIPTION
Fix for: `undefined method `each' for nil:NilClass (NoMethodError)` when calling `client.plans.update(plan, "__identifier__")` on a plan where `charges` is empty